### PR TITLE
Expand external schemas

### DIFF
--- a/src/app/factories/ramlParser.js
+++ b/src/app/factories/ramlParser.js
@@ -80,9 +80,11 @@
           api = api.expand ? api.expand(true) : api;
           var raml = api.toJSON(jsonOptions);
           if (raml.specification) {
-            ramlExpander.expandRaml(raml.specification);
+            return ramlExpander.expandRaml(raml.specification).then(function(){return raml;});
           }
-          return raml;
+          else {
+            return Promise.resolve(raml);
+          }
         });
 
         // ---


### PR DESCRIPTION
Done: URL ref expansion

TODO: in-file ref expansion (requires a separate pass since relative in-file refs can be nested)

Maybe TODO: local cross-file expansion. Requires to know the location of the schema in the file system. Should have been enabled by (this)[https://github.com/raml-org/raml-js-parser-2/issues/481#issuecomment-255270191], but I was not able to find `schemaPath` yet.